### PR TITLE
Stop submit event propagation

### DIFF
--- a/jquery.ajaxfileupload.js
+++ b/jquery.ajaxfileupload.js
@@ -90,7 +90,7 @@
               // let onStart have the option to cancel the upload
               if(ret !== false)
               {
-                $element.parent('form').submit();
+                $element.parent('form').submit(function(e) { e.stopPropagation(); }).submit();
               }
             }
           };


### PR DESCRIPTION
When using this plugin with Rails UJS and a form with the `data-remote` attribute, submitting the wrapper form causes the parent form to be submitted as well. Stopping the submit event propagation fixes this.
