### PR TITLE
dataType setting added to support JSON better

### DIFF
--- a/jquery.ajaxfileupload.js
+++ b/jquery.ajaxfileupload.js
@@ -15,11 +15,11 @@
         var settings = {
           params: {},
           action: '',
-          onStart: function() { console.log('starting upload'); console.log(this); },
-          onComplete: function(response) { console.log('got response: '); console.log(response); console.log(this); },
-          onCancel: function() { console.log('cancelling: '); console.log(this); },
-          validate_extensions : true,
-          valid_extensions : ['gif','png','jpg','jpeg'],
+          onStart: function() {},
+          onComplete: function(response) {},
+          onCancel: function() {},
+          validate_extensions : false,
+          valid_extensions : [],
           submit_button : null,
           dataType: 'html'
         };

--- a/jquery.ajaxfileupload.js
+++ b/jquery.ajaxfileupload.js
@@ -20,7 +20,8 @@
           onCancel: function() { console.log('cancelling: '); console.log(this); },
           validate_extensions : true,
           valid_extensions : ['gif','png','jpg','jpeg'],
-          submit_button : null
+          submit_button : null,
+          dataType: 'html'
         };
 
         var uploading_file = false;
@@ -104,7 +105,7 @@
           //  and clean up after ourselves. 
           */
           var handleResponse = function(loadedFrame, element) {
-            var response, responseStr = loadedFrame.contentWindow.document.body.innerHTML;
+            var response, responseStr = settings.dataType == 'json' ? loadedFrame.contentWindow.document.body.innerText : loadedFrame.contentWindow.document.body.innerHTML;
             try {
               //response = $.parseJSON($.trim(responseStr));
               response = JSON.parse(responseStr);

--- a/jquery.ajaxfileupload.js
+++ b/jquery.ajaxfileupload.js
@@ -26,17 +26,17 @@
 
         var uploading_file = false;
 
-        if ( options ) { 
+        if ( options ) {
           $.extend( settings, options );
         }
 
 
-        // 'this' is a jQuery collection of one or more (hopefully) 
+        // 'this' is a jQuery collection of one or more (hopefully)
         //  file elements, but doesn't check for this yet
         return this.each(function() {
           var $element = $(this);
 
-          // Skip elements that are already setup. May replace this 
+          // Skip elements that are already setup. May replace this
           //  with uninit() later, to allow updating that settings
           if($element.data('ajaxUploader-setup') === true) return;
 
@@ -78,10 +78,10 @@
               // Pass back to the user
               settings.onComplete.apply($element, [{status: false, message: 'The select file type is invalid. File must be ' + settings.valid_extensions.join(', ') + '.'}, settings.params]);
             } else
-            { 
+            {
               uploading_file = true;
 
-              // Creates the form, extra inputs and iframe used to 
+              // Creates the form, extra inputs and iframe used to
               //  submit / upload the file
               wrapElement($element);
 
@@ -101,8 +101,8 @@
           $element.data('ajaxUploader-setup', true);
 
           /*
-          // Internal handler that tries to parse the response 
-          //  and clean up after ourselves. 
+          // Internal handler that tries to parse the response
+          //  and clean up after ourselves.
           */
           var handleResponse = function(loadedFrame, element) {
             var response, responseStr = settings.dataType == 'json' ? loadedFrame.contentWindow.document.body.innerText : loadedFrame.contentWindow.document.body.innerHTML;
@@ -126,8 +126,8 @@
           /*
           // Wraps element in a <form> tag, and inserts hidden inputs for each
           //  key:value pair in settings.params so they can be sent along with
-          //  the upload. Then, creates an iframe that the whole thing is 
-          //  uploaded through. 
+          //  the upload. Then, creates an iframe that the whole thing is
+          //  uploaded through.
           */
           var wrapElement = function(element) {
             // Create an iframe to submit through, using a semi-unique ID


### PR DESCRIPTION
Added the 'dataType' setting to support JSON responses better. Chrome returns

`<pre style="word-wrap: break-word; white-space: pre-wrap;">{"success":true}</pre>`

because innerHTML was used. Using innerText doesn't make JSON.parse fail.
