### PR TITLE
Bugfix: submit button invalid when canceled

### DIFF
--- a/jquery.ajaxfileupload.js
+++ b/jquery.ajaxfileupload.js
@@ -95,6 +95,8 @@
               if(ret !== false)
               {
                 $element.parent('form').submit(function(e) { e.stopPropagation(); }).submit();
+              } else {
+                uploading_file = false;
               }
             }
           };
@@ -156,9 +158,6 @@
               return html;
             });
           }
-
-
-
         });
       }
 })( jQuery )


### PR DESCRIPTION
When cancel file uploading using onStart callback function , the submit button become invalid because forget to set `uploading_file = false`;

Sorry for my terrible english skill.